### PR TITLE
Handle pyramid level during CSV import

### DIFF
--- a/services.py
+++ b/services.py
@@ -186,14 +186,15 @@ def import_materials_csv(path: Path) -> dict:
             if s.query(RawMaterial).filter_by(name=row["name"]).first():
                 skipped += 1
                 continue
+            level_str = row.get("fragrance_pyramid_level")
+            level = PyramidLevel(level_str) if level_str else PyramidLevel.MIDDLE
             s.add(
                 RawMaterial(
                     name=row["name"],
                     category=row.get("category") or "",
                     cost_per_g=float(row.get("cost_per_g") or 0),
                     inventory_g=float(row.get("inventory_g") or 0),
-                    fragrance_pyramid_level=row.get("fragrance_pyramid_level")
-                    or PyramidLevel.MIDDLE,
+                    fragrance_pyramid_level=level,
                 )
             )
             added += 1


### PR DESCRIPTION
## Summary
- parse `fragrance_pyramid_level` column in `import_materials_csv`
- default to middle level when not provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2309813c832b90e2f7dc7a2f012f