### PR TITLE
Fix engine import in sync script

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -6,13 +6,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import URL
 from sqlalchemy_utils import database_exists, create_database
 
-from models import Base, get_engine
+from models import Base, engine
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--pg-url", default=os.getenv("PGURL"), required=True)
 args = parser.parse_args()
 
-local_engine = get_engine()
+local_engine = engine
 pg_engine = create_engine(URL.create(args.pg_url), future=True)
 
 if not database_exists(pg_engine.url):


### PR DESCRIPTION
## Summary
- import the SQLAlchemy engine directly from `models`
- adjust `sync.py` to use `engine` variable

## Testing
- `python -m py_compile sync.py`
- `python sync.py --pg-url sqlite:////tmp/test.db` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684f20c21b34832badd38c37cb784f48