### PR TITLE
Refactor user state to session context

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,25 +1,15 @@
 # auth.py ── autenticación simple
 
 from passlib.hash import pbkdf2_sha256
-from models import SessionLocal, User, Role
-
-_current_user: User | None = None
+from models import SessionLocal, User
+from session import set_current_user
 
 
 def login(username: str, password: str) -> bool:
-    global _current_user
     with SessionLocal() as s:
         user = s.query(User).filter_by(username=username, is_active=True).first()
         if user and pbkdf2_sha256.verify(password, user.password_hash):
-            _current_user = user
+            set_current_user(user)
             return True
     return False
 
-
-def current_user() -> User | None:
-    return _current_user
-
-
-def require_role(*roles: Role) -> bool:
-    u = current_user()
-    return bool(u and u.role in roles)

--- a/gui.py
+++ b/gui.py
@@ -34,8 +34,9 @@ from dialogs import (
     FormulaDialog,
     RevisionDiffDialog,
 )
-from auth import login, current_user, require_role, Role
-from models import RawMaterial, Formula
+from auth import login
+from session import current_user, require_role
+from models import RawMaterial, Formula, Role
 
 
 # ---------------------------------------------------------------------------#

--- a/services.py
+++ b/services.py
@@ -20,7 +20,7 @@ from models import (
     PyramidLevel,
     AuditLog,
 )
-from auth import current_user, Role
+from session import current_user
 
 # ---------------------------------------------------------------------------#
 # Session helper

--- a/session.py
+++ b/session.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5.QtWidgets import QApplication
+
+from models import User, Role
+
+
+def set_current_user(user: Optional[User]) -> None:
+    app = QApplication.instance()
+    if app:
+        app.setProperty("current_user", user)
+
+
+def current_user() -> Optional[User]:
+    app = QApplication.instance()
+    if app:
+        return app.property("current_user")
+    return None
+
+
+def require_role(*roles: Role) -> bool:
+    u = current_user()
+    return bool(u and u.role in roles)


### PR DESCRIPTION
## Summary
- introduce `session` module storing current user via `QApplication`
- update `auth.login` to save user in session
- get current user from the new session in GUI and services

## Testing
- `python -m py_compile auth.py services.py gui.py session.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f20e8a390832b99eecd52e4fb3ddc